### PR TITLE
Feature: update `definition dl-os` command

### DIFF
--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -425,9 +425,14 @@ def download_os():
 
     file_name = handler.get_os_zip_filename()
 
-    print('Download CyanogenMod for and save the file as\n - %s\n'
-          'into the resources folder, then verify the file checksum.\n - %s\n'
-          % (file_name, url))
+    message = '\n'.join((
+        'Download CyanogenMod from:\n - %s',
+        'and save the file as\n - %s',
+        'into the resources folder, and remember to open a new terminal and',
+        'verify the that provided md5 checksum matches the the output of:',
+        ' ~$ md5sum resources/%s',
+    ))
+    print(message % (url, file_name, file_name))
 
     input_pause('Please follow the instructions before continuing!')
 

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -405,6 +405,10 @@ def download_apps():
 
 
 def download_os():
+    """
+    Display information to the user on how to download the OS and verify it's
+    checksum.
+    """
     print('\nNOTE: Command not finished yet; See instructions!\n')
 
     # Get the MIA handler singleton.
@@ -434,7 +438,17 @@ def download_os():
     ))
     print(message % (url, file_name, file_name))
 
-    input_pause('Please follow the instructions before continuing!')
+    # Make sure the OS archive exists.
+    zip_file_path = os.path.join(resources_path, file_name)
+    while True:
+        input_pause('Please follow the instructions before continuing.')
+
+        # Only allow the user to continue if the OS image exists.
+        if os.path.isfile(zip_file_path):
+            break
+
+        # Display message and try again.
+        print('File not found:\n - %s' % zip_file_path)
 
 
 def extract_update_binary():

--- a/mia/helpers/utils.py
+++ b/mia/helpers/utils.py
@@ -149,7 +149,7 @@ class MiaHandler():
 
 
 def input_pause(display_text='Paused.'):
-    input("%s\nPress enter to continue!\n" % display_text)
+    input("%s\nPress enter to continue.\n" % display_text)
 
 
 def input_confirm(display_text='Confirm', default_value=False):


### PR DESCRIPTION
I've added a remainder for the user to verify the checksum of the downloaded OS archive.

I've also updated the command to wait for the user to put the OS archive in the right place before continuing with the next command or ending out of the program.