### PR TITLE
Disable Probes for Configured Wifi Networks

### DIFF
--- a/mia/templates/mia-default/settings.yaml
+++ b/mia/templates/mia-default/settings.yaml
@@ -75,3 +75,4 @@ apps:
   - id: org.sufficientlysecure.localcalendar
   - id: org.torproject.android
   - id: org.videolan.vlc
+  - id: be.uhasselt.privacypolice


### PR DESCRIPTION
The Wi-Fi Privacy Police app prevents your smartphone or tablet from leaking stored SSID it wants to connect to. Open source and non root.
https://f-droid.org/repository/browse/?fdid=be.uhasselt.privacypolice