### PR TITLE
Improve/fix schema tests

### DIFF
--- a/docs/current.settings.yaml
+++ b/docs/current.settings.yaml
@@ -8,6 +8,7 @@ general:
 
 defaults:
   repository: fdroid
+  app_type: user
 
 app_types:
   system: system/app
@@ -22,10 +23,6 @@ repositories:
   - id: fdroid_archive
     name: F-Droid Archive
     url: https://f-droid.org/archive
-
-defaults:
-  repository_id: fdroid
-  install_type: user
 
 apps:
 - id: org.fdroid.fdroid

--- a/docs/current.settings.yaml
+++ b/docs/current.settings.yaml
@@ -23,6 +23,10 @@ repositories:
     name: F-Droid Archive
     url: https://f-droid.org/archive
 
+defaults:
+  repository_id: fdroid
+  install_type: user
+
 apps:
 - id: org.fdroid.fdroid
   versioncode: 830

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -18,7 +18,7 @@ apps: >
   )
 
 defaults:
-  repository_id: str()
+  repository: str()
   app_type: str(required=False)
 
 ---

--- a/docs/target.settings.yaml
+++ b/docs/target.settings.yaml
@@ -9,7 +9,7 @@ general:
     - wifi-only
 
 defaults:
-  repository_id: fdroid
+  repository: fdroid
   app_type: user
 
 app_types:

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -237,8 +237,8 @@ class Definition(object):
         # Read the definition settings.
         settings = MiaHandler.get_definition_settings()
 
-        if not settings['defaults']['repository_id']:
-            print('Missing default repository id.')
+        if not settings['defaults']['repository']:
+            print('Missing default repository setting.')
             sys.exit(1)
 
         # Make sure the resources folder exists.
@@ -285,7 +285,7 @@ class Definition(object):
             if 'id' in app_info:
                 # Use the default repository if no repo has been provided.
                 if 'repo' not in app_info:
-                    app_info['repo'] = settings['defaults']['repository_id']
+                    app_info['repo'] = settings['defaults']['repository']
 
                 # Use the latest application version code.
                 if MiaHandler.args['--force-latest'] or 'versioncode' not in app_info:
@@ -294,7 +294,7 @@ class Definition(object):
                 # Get the application info.
                 lock_info = MiaFDroid.fdroid_get_app_lock_info(repositories_data, app_info)
                 if lock_info is not None:
-                    repo_id = lock_info['repository_id']
+                    repo_id = lock_info['repository']
                     repo_name = repositories_data[repo_id]['name']
                     msg = ' - found `%s` in the %s repository.'
                     print(msg % (lock_info['id'], repo_name))

--- a/mia/fdroid.py
+++ b/mia/fdroid.py
@@ -39,7 +39,7 @@ class MiaFDroid(object):
             data[repo]['url'].strip('/'),
             app_lock_info['package_name']
         )
-        app_lock_info['repository_id'] = repo
+        app_lock_info['repository'] = repo
         app_lock_info['type'] = app_info.get('type', 'user')
 
         return app_lock_info

--- a/mia/templates/mia-default/settings.yaml
+++ b/mia/templates/mia-default/settings.yaml
@@ -12,7 +12,7 @@ general:
 
 defaults:
   # The default repository for apps.
-  repository_id: fdroid
+  repository: fdroid
 
 app_types:
   system: system/app

--- a/test/validate_settings_templates.py
+++ b/test/validate_settings_templates.py
@@ -1,9 +1,15 @@
+from glob import glob
+import sys
 import yamale
 
 schema = yamale.make_schema('./docs/schema.yaml')
 
-data = yamale.make_data('./docs/target.settings.yaml')
+data = yamale.make_data('./docs/current.settings.yaml')
 yamale.validate(schema, data)
 
-data = yamale.make_data('./mia/templates/mia-default/settings.yaml')
-yamale.validate(schema, data)
+templates = glob('mia/templates/*/settings.yaml')
+for template in templates:
+    sys.stdout.write('Checking %s against schema... ' % template)
+    data = yamale.make_data(template)
+    yamale.validate(schema, data)
+    print("done!")


### PR DESCRIPTION
The seems like a mistake: https://github.com/mission-impossible-android/mission-impossible-android/blob/master/test/validate_settings_templates.py#L5

It should check the current, not target? :/

We should glob and check all templates, rather than just `mia-default`:
https://github.com/mission-impossible-android/mission-impossible-android/blob/master/test/validate_settings_templates.py#L8