### PR TITLE
Feature: sanity check

### DIFF
--- a/docs/current.settings.yaml
+++ b/docs/current.settings.yaml
@@ -25,12 +25,12 @@ repositories:
     url: https://f-droid.org/archive
 
 apps:
-- id: org.fdroid.fdroid
-  versioncode: 830
-  app_type: system
-- id: info.guardianproject.orfox
-  url: https://guardianproject.info/builds/OrfoxFennec/latest/OrfoxFennec-debug.apk
-- id: com.artifex.mupdfdemo
-  version: 1.2.3
-- org.torproject.android
-- org.videolan.vlc
+  - id: org.fdroid.fdroid
+    versioncode: 830
+    app_type: system
+  - id: info.guardianproject.orfox
+    url: https://guardianproject.info/builds/OrfoxFennec/latest/OrfoxFennec-debug.apk
+  - id: com.artifex.mupdfdemo
+    version: 1.2.3
+  - org.torproject.android
+  - org.videolan.vlc

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -20,7 +20,7 @@ apps: >
 defaults:
   repository: str()
   app_type: str(required=False)
-  hash_type: str()
+  hash_type: str(required=False)
 
 ---
 
@@ -39,7 +39,7 @@ app_fdroid_version:
   id: str()
   version: str()
   hash: str()
-  hash_type: str()
+  hash_type: str(required=False)
   repository: str(required=False)
   app_type: enum('system', 'privileged', 'user', required=False)
 
@@ -47,7 +47,7 @@ app_fdroid_versioncode:
   id: str()
   versioncode: int()
   hash: str()
-  hash_type: str()
+  hash_type: str(required=False)
   repository: str(required=False)
   app_type: enum('system', 'privileged', 'user', required=False)
 
@@ -55,6 +55,6 @@ app_direct_download:
   id: str()
   name: str()
   hash: str()
-  hash_type: str()
+  hash_type: str(required=False)
   url: str()
   app_type: enum('system', 'privileged', 'user', required=False)

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -20,6 +20,7 @@ apps: >
 defaults:
   repository: str()
   app_type: str(required=False)
+  hash_type: str()
 
 ---
 
@@ -37,17 +38,23 @@ app_fdroid_latest:
 app_fdroid_version:
   id: str()
   version: str()
+  hash: str()
+  hash_type: str()
   repository: str(required=False)
   app_type: enum('system', 'privileged', 'user', required=False)
 
 app_fdroid_versioncode:
   id: str()
   versioncode: int()
+  hash: str()
+  hash_type: str()
   repository: str(required=False)
   app_type: enum('system', 'privileged', 'user', required=False)
 
 app_direct_download:
   id: str()
   name: str()
+  hash: str()
+  hash_type: str()
   url: str()
   app_type: enum('system', 'privileged', 'user', required=False)

--- a/docs/target.settings.yaml
+++ b/docs/target.settings.yaml
@@ -11,6 +11,7 @@ general:
 defaults:
   repository: fdroid
   app_type: user
+  hash_type: sha256
 
 app_types:
   system: system/app
@@ -28,11 +29,14 @@ repositories:
 
 apps:
 - id: org.fdroid.fdroid
-  versioncode: 830
+  versioncode: 920
+  hash: 0e949b83d48d882ce70e1e405d25173f572b32623a8a8f58394193d3eac08f31
   app_type: system
 - id: info.guardianproject.orfox
   name: Orfox
   url: https://guardianproject.info/builds/OrfoxFennec/latest/OrfoxFennec-debug.apk
+  hash: be85ee0f127d852b052715290e7e29ff
+  hash_type: md5
 - id: com.artifex.mupdfdemo
   version: 1.2.3
 - org.torproject.android

--- a/docs/target.settings.yaml
+++ b/docs/target.settings.yaml
@@ -28,16 +28,16 @@ repositories:
     url: https://f-droid.org/archive
 
 apps:
-- id: org.fdroid.fdroid
-  versioncode: 920
-  hash: 0e949b83d48d882ce70e1e405d25173f572b32623a8a8f58394193d3eac08f31
-  app_type: system
-- id: info.guardianproject.orfox
-  name: Orfox
-  url: https://guardianproject.info/builds/OrfoxFennec/latest/OrfoxFennec-debug.apk
-  hash: be85ee0f127d852b052715290e7e29ff
-  hash_type: md5
-- id: com.artifex.mupdfdemo
-  version: 1.2.3
-- org.torproject.android
-- org.videolan.vlc
+  - id: org.fdroid.fdroid
+    versioncode: 920
+    hash: 0e949b83d48d882ce70e1e405d25173f572b32623a8a8f58394193d3eac08f31
+    app_type: system
+  - id: info.guardianproject.orfox
+    name: Orfox
+    url: https://guardianproject.info/builds/OrfoxFennec/latest/OrfoxFennec-debug.apk
+    hash: be85ee0f127d852b052715290e7e29ff
+    hash_type: md5
+  - id: com.artifex.mupdfdemo
+    version: 1.2.3
+  - org.torproject.android
+  - org.videolan.vlc

--- a/mia/android.py
+++ b/mia/android.py
@@ -92,7 +92,7 @@ class MiaAndroid(object):
     def set_open_recovery_script(cls):
         # Push the open recovery script to the device.
         script_path = os.path.join(MiaHandler.get_definition_path(), 'other', 'openrecoveryscript')
-        cls.push_file_to_device('file', script_path, '/sdcard/openrecoveryscript')
+        cls.push_file('file', script_path, '/sdcard/openrecoveryscript')
 
         # TODO: See whether `su` is really required, works fine in recovery mode?!?
         command = 'su root cp /sdcard/openrecoveryscript /cache/recovery/openrecoveryscript'
@@ -107,7 +107,7 @@ class MiaAndroid(object):
             raise RuntimeError('Could not set the open recovery script!')
 
     @classmethod
-    def push_file_to_device(cls, source_type, source, destination):
+    def push_file(cls, source_type, source, destination):
         # Get the file size.
         file_size = os.path.getsize(source)
 

--- a/mia/commands/build.py
+++ b/mia/commands/build.py
@@ -79,7 +79,7 @@ class Build(object):
             if os.path.exists(hash_file_path):
                 os.remove(hash_file_path)
 
-        print('Build finished successfully:', ' - {}'.format(zip_path), sep='\n')
+        print('Build finished successfully:\n - {}'.format(zip_path))
 
         return None
 

--- a/mia/commands/build.py
+++ b/mia/commands/build.py
@@ -50,7 +50,7 @@ class Build(object):
         # Open a ZIP file.
         zf = zipfile.ZipFile(zip_path, mode='w', compression=zipfile.ZIP_DEFLATED)
 
-        # TODO: Verify available hashes for files added to the generated update.zip.
+        # Build the ZIP file.
         archive_root_directory_path = os.path.join(definition_path, 'archive')
         for entry in glob.glob(archive_root_directory_path + '/*'):
             # Allow only directories at the root of the generated update.zip
@@ -71,11 +71,12 @@ class Build(object):
         # Only generate hash upon successful build. Keeping the old hash
         # will help prevent installing broken update.zip files.
         if not MiaHandler.args['--no-hash']:
-            # TODO: Verify hash during the install process.
-            MiaUtils.create_hash_file(zip_path)
+            # NOTE: For now the TWRP OpenRecoveryScript only supports md5.
+            # @see https://github.com/TeamWin/Team-Win-Recovery-Project/issues/450
+            MiaUtils.create_hash_file(zip_path, 'md5')
         else:
             # Remove hash from previous build.
-            hash_file_path = '.'.join((zip_path, 'SHA256SUM'))
+            hash_file_path = '.'.join((zip_path, 'md5'))
             if os.path.exists(hash_file_path):
                 os.remove(hash_file_path)
 

--- a/mia/commands/build.py
+++ b/mia/commands/build.py
@@ -3,42 +3,54 @@ This command can be used to generate a custom update.zip file using information
 from a definition.
 
 Usage:
-    mia build <definition>
+    mia build [--no-hash] <definition>
     mia build --help
+
+Command options:
+    --no-hash  Build faster, skip hash computation.
+
+
+WARNING:
+  Skipping the hash computation will allow you to install incomplete or broken
+  builds onto your device.
 
 
 """
 
 import glob
 import os
+import sys
 import zipfile
 
 # Import custom helpers.
 from mia.commands import available_commands
 from mia.handler import MiaHandler
+from mia.utils import MiaUtils
 
 
 class Build(object):
     @classmethod
     def main(cls):
-        # Read the definition settings.
-        settings = MiaHandler.get_definition_settings()
         definition_path = MiaHandler.get_definition_path()
 
-        # Create the builds folder.
+        # Create the builds directory.
         builds_path = os.path.join(MiaHandler.get_workspace_path(), 'builds')
         if not os.path.isdir(builds_path):
             os.makedirs(builds_path, mode=0o755)
 
-        zip_name = '%s.%s' % (MiaHandler.args['<definition>'], 'mia-update.zip')
+        zip_name = '.'.join((
+            MiaHandler.args['<definition>'],
+            'mia-update.zip',
+        ))
         zip_path = os.path.join(MiaHandler.get_workspace_path(), 'builds', zip_name)
         if os.path.exists(zip_path):
-            print('Deleting current build:\n - %s\n' % zip_path)
+            print('Deleting current build: {}'.format(zip_path))
             os.remove(zip_path)
 
         # Open a ZIP file.
-        zf = zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED)
+        zf = zipfile.ZipFile(zip_path, mode='w', compression=zipfile.ZIP_DEFLATED)
 
+        # TODO: Verify available hashes for files added to the generated update.zip.
         archive_root_directory_path = os.path.join(definition_path, 'archive')
         for entry in glob.glob(archive_root_directory_path + '/*'):
             # Allow only directories at the root of the generated update.zip
@@ -46,18 +58,34 @@ class Build(object):
                 continue
 
             destination = os.path.basename(entry)
-            print('Adding "%s" directory to the archive:' % destination)
+            print('Adding "{}" directory to the archive:'.format(destination))
             cls.add_directory_to_zip(zf, entry, destination)
 
-        # Close the ZIP file.
+        # Make sure the created file is valid.
+        print('Verifying built mia-update.zip file...')
+        bad_file = zf.testzip()
         zf.close()
-        print('\n' + 'Finished creating:\n - %s' % zip_path)
+        if bad_file:
+            sys.exit('Created zip file is corrupted: {!r}'.format(bad_file))
+
+        # Only generate hash upon successful build. Keeping the old hash
+        # will help prevent installing broken update.zip files.
+        if not MiaHandler.args['--no-hash']:
+            # TODO: Verify hash during the install process.
+            MiaUtils.create_hash_file(zip_path)
+        else:
+            # Remove hash from previous build.
+            hash_file_path = '.'.join((zip_path, 'SHA256SUM'))
+            if os.path.exists(hash_file_path):
+                os.remove(hash_file_path)
+
+        print('Build finished successfully:', ' - {}'.format(zip_path), sep='\n')
 
         return None
 
     @staticmethod
     def add_directory_to_zip(zf, source, destination):
-        for path, folders, files in os.walk(source):
+        for path, directories, files in os.walk(source):
             for file_name in files:
                 rel_path = os.path.relpath(path, source)
                 if rel_path != '.':
@@ -65,7 +93,7 @@ class Build(object):
                 else:
                     path_in_zip = os.path.join(destination, file_name)
 
-                print(' - %s' % path_in_zip)
+                print(' - {}'.format(path_in_zip))
                 zf.write(os.path.join(path, file_name), path_in_zip)
 
 

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -285,8 +285,8 @@ class Definition(object):
             # Lookup the app by id and versioncode in the repository index.xml.
             if 'id' in app_info:
                 # Use the default repository if it has not been provided.
-                if 'repo' not in app_info:
-                    app_info['repo'] = settings['defaults']['repository']
+                if 'repository' not in app_info:
+                    app_info['repository'] = settings['defaults']['repository']
 
                 # Use the default app_type if it has not been provided.
                 if 'type' not in app_info:

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -372,6 +372,8 @@ class Definition(object):
 
                 if apk_hash_value != apk_info['hash']:
                     sys.exit('WARNING: Unexpected hash for downloaded apk!')
+                else:
+                    print('   - file hash is OK.')
 
         print('Finished downloading APKs and verifying their hash values.')
 

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -272,9 +272,11 @@ class Definition(object):
             if 'url' in app_info:
                 lock_info = {
                     'id': app_info['id'],
-                    'package_name': os.path.basename(app_info['url']),
+                    'package_name': app_info['name'],
                     'package_url': app_info['url'],
-                    'type': app_info.get('type', 'user')
+                    'type': app_info.get('type', settings['defaults']['app_type']),
+                    'hash': app_info['hash'],
+                    'hash_type': app_info.get('hash_type', settings['defaults']['hash_type']),
                 }
 
                 print(' - adding `%s`' % lock_info['id'])
@@ -283,9 +285,17 @@ class Definition(object):
 
             # Lookup the app by id and versioncode in the repository index.xml.
             if 'id' in app_info:
-                # Use the default repository if no repo has been provided.
+                # Use the default repository if it has not been provided.
                 if 'repo' not in app_info:
                     app_info['repo'] = settings['defaults']['repository']
+
+                # Use the default app_type if it has not been provided.
+                if 'type' not in app_info:
+                    app_info['type'] = settings['defaults']['app_type']
+
+                # Use the default hash_type if it has not been provided.
+                if 'hash' in app_info and 'hash_type' not in app_info:
+                    app_info['hash_type'] = settings['defaults']['hash_type']
 
                 # Use the latest application version code.
                 if MiaHandler.args['--force-latest'] or 'versioncode' not in app_info:
@@ -293,19 +303,31 @@ class Definition(object):
 
                 # Get the application info.
                 lock_info = MiaFDroid.fdroid_get_app_lock_info(repositories_data, app_info)
-                if lock_info is not None:
-                    repo_id = lock_info['repository']
-                    repo_name = repositories_data[repo_id]['name']
-                    msg = ' - found `%s` in the %s repository.'
-                    print(msg % (lock_info['id'], repo_name))
-                    apps_list.append(lock_info)
+
+                if lock_info is None:
+                    msg = ' - app `%s` is missing'
+                    print(msg % (app_info['id']))
+                    warnings_found = True
                     continue
 
-            warnings_found = True
+                repo_id = lock_info['repository']
+                repo_name = repositories_data[repo_id]['name']
+
+                if 'hash' in lock_info and 'hash' in app_info and lock_info['hash'] != app_info['hash']:
+                    msg = ' - mismatching hash for `%s` in the %s repository.'
+                    print(msg % (lock_info['id'], repo_name))
+                    warnings_found = True
+                    continue
+
+                msg = ' - found `%s` in the %s repository.'
+                print(msg % (lock_info['id'], repo_name))
+                apps_list.append(lock_info)
 
         # Give the user a chance to fix any possible errors.
-        if warnings_found and not MiaUtils.input_confirm('Warnings found! Continue?'):
-            sys.exit(1)
+        if warnings_found:
+            msg = 'Warnings found, some APKs will not be downloaded! Continue?'
+            if not MiaUtils.input_confirm(msg):
+                sys.exit(1)
 
         return apps_list
 
@@ -342,6 +364,8 @@ class Definition(object):
                 print('   - already downloaded, using cached apk.')
             else:
                 raise Exception('   - error downloading file.')
+
+        print('Finished downloading APKs.')
 
     @staticmethod
     def download_os():

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -363,7 +363,15 @@ class Definition(object):
             elif http_message['status_code'] == 416:
                 print('   - already downloaded, using cached apk.')
             else:
-                raise Exception('   - error downloading file.')
+                print('   - error downloading file.')
+                if not MiaUtils.input_confirm('Continue?', True):
+                    sys.exit('Download aborted!')
+
+            if os.path.exists(apk_path) and 'hash' in apk_info:
+                apk_hash_value = MiaUtils.get_file_hash(apk_path, apk_info['hash_type'])
+
+                if apk_hash_value != apk_info['hash']:
+                    sys.exit('WARNING: Unexpected hash for downloaded apk!')
 
         print('Finished downloading APKs.')
 

--- a/mia/commands/definition.py
+++ b/mia/commands/definition.py
@@ -208,7 +208,6 @@ class Definition(object):
         if MiaUtils.input_confirm('Download apps now?', True):
             cls.download_apps()
 
-    # TODO: Implement the APK lock functionality.
     @classmethod
     def create_apps_lock_file(cls):
         # Get the APK lock data.
@@ -367,13 +366,14 @@ class Definition(object):
                 if not MiaUtils.input_confirm('Continue?', True):
                     sys.exit('Download aborted!')
 
+            # TODO: Verify signatures?!?
             if os.path.exists(apk_path) and 'hash' in apk_info:
                 apk_hash_value = MiaUtils.get_file_hash(apk_path, apk_info['hash_type'])
 
                 if apk_hash_value != apk_info['hash']:
                     sys.exit('WARNING: Unexpected hash for downloaded apk!')
 
-        print('Finished downloading APKs.')
+        print('Finished downloading APKs and verifying their hash values.')
 
     @staticmethod
     def download_os():

--- a/mia/commands/install.py
+++ b/mia/commands/install.py
@@ -55,11 +55,11 @@ class Install(object):
         android = MiaAndroid()
 
         # Push the mia-update.zip to the device.
-        android.push_file_to_device('update archive', update_zip_path, '/sdcard/mia-update.zip')
+        android.push_file('update archive', update_zip_path, '/sdcard/mia-update.zip')
 
         # Push the mia-os.zip to the device.
         if not MiaHandler.args['--skip-os']:
-            android.push_file_to_device('OS archive', os_zip_path, '/sdcard/mia-os.zip')
+            android.push_file('OS archive', os_zip_path, '/sdcard/mia-os.zip')
 
         if MiaHandler.args['--push-only']:
             print('\n' + 'Finished pushing the files onto the device.')

--- a/mia/commands/install.py
+++ b/mia/commands/install.py
@@ -13,7 +13,7 @@ Command options:
     --skip-os    Do not push the OS zip file (again). Install the existing one.
 
 Notes:
-  * A prior push is required when using `--skip-os` for a successful install.
+  * For a successful install a prior push is required when using `--skip-os`.
 
 
 """
@@ -30,47 +30,65 @@ from mia.handler import MiaHandler
 class Install(object):
     @staticmethod
     def main():
-        # TODO: Make sure build is successful before running the installer.
         if MiaHandler.args['--build']:
             build_command_handler = Build()
             build_command_handler.main()
 
-        # Create the builds folder.
-        update_zip_name = '%s.%s' % (MiaHandler.args['<definition>'], 'mia-update.zip')
-        update_zip_path = os.path.join(MiaHandler.get_workspace_path(), 'builds', update_zip_name)
+        # Push the update archive and hash file to the device.
+        Install.push_update_zip()
 
-        if not os.path.isfile(update_zip_path):
-            print('ERROR: Please run the build command first.')
-            sys.exit(1)
-
-        # Get the OS file name.
-        os_zip_name = MiaHandler.get_os_zip_filename()
-        os_zip_path = os.path.join(MiaHandler.get_workspace_path(), 'resources', os_zip_name)
-
-        if not os.path.isfile(os_zip_path):
-            print('ERROR: OS archive not found.')
-            sys.exit(1)
-
-        # Get the android device wrapper.
-        android = MiaAndroid()
-
-        # Push the mia-update.zip to the device.
-        android.push_file('update archive', update_zip_path, '/sdcard/mia-update.zip')
-
-        # Push the mia-os.zip to the device.
         if not MiaHandler.args['--skip-os']:
-            android.push_file('OS archive', os_zip_path, '/sdcard/mia-os.zip')
+            # Push the OS archive and hash file to the device.
+            Install.push_os_zip()
 
         if MiaHandler.args['--push-only']:
             print('\n' + 'Finished pushing the files onto the device.')
             sys.exit(0)
 
         # Set the openrecoveryscript.
-        android.set_open_recovery_script()
+        MiaAndroid.set_open_recovery_script()
 
         if not MiaHandler.args['--no-reboot']:
             print('\n' + 'Rebooting the device into recovery...')
-            android.reboot_device('recovery')
+            MiaAndroid.reboot_device('recovery')
+
+    @staticmethod
+    def push_os_zip():
+        # Get the OS file name.
+        zip_name = MiaHandler.get_os_zip_filename()
+        zip_path = os.path.join(MiaHandler.get_workspace_path(), 'resources', zip_name)
+
+        if not os.path.isfile(zip_path):
+            print('ERROR: OS archive is missing:\n - %s' % zip_path)
+            sys.exit(1)
+
+        os_zip_hash_path = '.'.join((zip_path, 'md5'))
+        if not os.path.isfile(os_zip_hash_path):
+            print('ERROR: Hash file for the OS archive is missing.')
+            sys.exit(1)
+
+        # Push the mia-os.zip to the device.
+        MiaAndroid.push_file('OS archive', zip_path, '/sdcard/mia-os.zip')
+        MiaAndroid.push_hash_for_file('md5', zip_path, '/sdcard/mia-os.zip')
+
+    @staticmethod
+    def push_update_zip():
+        # Create the builds folder.
+        zip_name = '%s.%s' % (MiaHandler.args['<definition>'], 'mia-update.zip')
+        zip_path = os.path.join(MiaHandler.get_workspace_path(), 'builds', zip_name)
+
+        if not os.path.isfile(zip_path):
+            print('ERROR: Please run the build command first.')
+            sys.exit(1)
+
+        update_zip_hash_path = '.'.join((zip_path, 'md5'))
+        if not os.path.isfile(update_zip_hash_path):
+            print('ERROR: Hash file for the built update archive is missing.')
+            sys.exit(1)
+
+        # Push the mia-update.zip to the device.
+        MiaAndroid.push_file('update archive', zip_path, '/sdcard/mia-update.zip')
+        MiaAndroid.push_hash_for_file('md5', zip_path, '/sdcard/mia-update.zip')
 
 
 # Add command to the list of available commands.

--- a/mia/fdroid.py
+++ b/mia/fdroid.py
@@ -10,9 +10,9 @@ class MiaFDroid(object):
         app_lock_info = None
 
         # Prepare a list of repositories to look into.
-        repositories = [app_info['repo']]
-        if 'fallback' in data[app_info['repo']]:
-            repositories.append(data[app_info['repo']]['fallback'])
+        repositories = [app_info['repository']]
+        if 'fallback' in data[app_info['repository']]:
+            repositories.append(data[app_info['repository']]['fallback'])
 
         for repo in repositories:
             # TODO: Improve detection!

--- a/mia/fdroid.py
+++ b/mia/fdroid.py
@@ -46,6 +46,11 @@ class MiaFDroid(object):
 
     @staticmethod
     def _fdroid_index_get_app_info(tag, target_versioncode):
+        """
+        :type tag: xml.etree.ElementTree.Element
+        :type target_versioncode: str
+        :rtype: dict
+        """
         package = None
         if target_versioncode == 'latest':
             package = tag.find('package')
@@ -64,4 +69,6 @@ class MiaFDroid(object):
             'name': tag.find('name').text,
             'package_name': package.find('apkname').text,
             'package_versioncode': package.find('versioncode').text,
+            'hash': package.find('hash').text,
+            'hash_type': package.find('hash').get('type'),
         }

--- a/mia/handler.py
+++ b/mia/handler.py
@@ -115,8 +115,15 @@ class MiaHandler:
                 print('ERROR: Could not read configuration file!')
                 sys.exit(1)
 
-            if settings:
-                cls.__definition_settings = settings
+            # Set 'user' as default app_type if none was provided.
+            if 'app_type' not in settings['defaults']:
+                settings['defaults']['app_type'] = 'user'
+
+            # Set 'sha256' as default hash_type if none was provided.
+            if 'hash_type' not in settings['defaults']:
+                settings['defaults']['hash_type'] = 'sha256'
+
+            cls.__definition_settings = settings
 
         return cls.__definition_settings
 

--- a/mia/templates/mia-default/other/openrecoveryscript
+++ b/mia/templates/mia-default/other/openrecoveryscript
@@ -1,7 +1,11 @@
 wipe dalvik
 wipe cache
 wipe data
+
+set tw_force_md5_check 1
 set tw_signed_zip_verify 1
+
 install /sdcard/mia-os.zip
 set tw_signed_zip_verify 0
+
 install /sdcard/mia-update.zip

--- a/mia/templates/mia-default/settings.yaml
+++ b/mia/templates/mia-default/settings.yaml
@@ -32,8 +32,8 @@ repositories:
 # Apps from the main F-Droid repository.
 apps:
   - id: org.fdroid.fdroid
-    versioncode: 930
-    hash: 436e676d9b965ae50175e08513d29e73236b0dddca7b80dd4dd50711268f5dce
+    versioncode: 920
+    hash: 0e949b83d48d882ce70e1e405d25173f572b32623a8a8f58394193d3eac08f31
     app_type: privileged
   - id: info.guardianproject.orfox
     name: info.guardianproject.orfox.20140822.apk

--- a/mia/templates/mia-default/settings.yaml
+++ b/mia/templates/mia-default/settings.yaml
@@ -32,12 +32,18 @@ repositories:
 # Apps from the main F-Droid repository.
 apps:
   - id: org.fdroid.fdroid
-    versioncode: 920
+    versioncode: 930
+    hash: 436e676d9b965ae50175e08513d29e73236b0dddca7b80dd4dd50711268f5dce
     app_type: privileged
   - id: info.guardianproject.orfox
+    name: info.guardianproject.orfox.20140822.apk
     url: https://guardianproject.info/builds/OrfoxFennec/2014-08-22_23-32-22/OrfoxFennec-debug.apk
+    hash: 90b5a851ac855d2e58a9f09fd4c6eda4977e9746fa1ddca766d30549621722fc
   - id: org.anhonesteffort.flock
+    name: org.anhonesteffort.flock.v27.apk
+    # @see https://flock-supplychain.anhonesteffort.org/packages/org.anhonesteffort.flock/current
     url: https://flock-supplychain.s3.amazonaws.com/apks/org.anhonesteffort.flock-4b93f078-cae6-4997-a1c2-ef833b2ac2c1.apk
+    hash: b92a03e8bea7fad9bda5bb31b4d6f2f4d859f7a05436f27f86da32331f37e271
   - id: com.artifex.mupdfdemo
   - id: com.csipsimple
   - id: com.fsck.k9

--- a/mia/utils.py
+++ b/mia/utils.py
@@ -239,7 +239,16 @@ class MiaUtils(object):
         raw_response_data = stderr.splitlines()[0]
         raw_headers = stderr.splitlines()[1:-1]
 
-        matches = re.match(r'^ *HTTP/[\d\.]+ (?P<code>\d{3}) (?P<msg>[\w ]*)$', raw_response_data.decode())
+        if sys.version_info.major == 2:
+            # In PY2 raw_response_data is actually a string
+            response_message = raw_response_data
+        else:
+            response_message = raw_response_data.decode()
+
+        matches = re.match(r'^ *HTTP/[\d\.]+ (?P<code>\d{3}) (?P<msg>[\w ]*)$', response_message)
+
+        if matches is None:
+            sys.exit('Error downloading file:\n{}'.format(response_message))
 
         response_data = {
             'status_code': int(matches.group('code')),

--- a/mia/utils.py
+++ b/mia/utils.py
@@ -108,16 +108,16 @@ class MiaUtils(object):
             return hashlib.new(hash_type, file_object.read()).hexdigest()
 
     @classmethod
-    def create_hash_file(cls, file_path):
+    def create_hash_file(cls, file_path, hash_type):
         # Get the human readable file size.
         file_size = os.path.getsize(file_path)
         file_size = cls.format_file_size(file_size)
 
         # Get the file hash.
         print(' - computing hash of {}'. format(file_size))
-        zip_hash_value = cls.get_file_hash(file_path)
+        zip_hash_value = cls.get_file_hash(file_path, hash_type)
 
-        hash_file_path = '.'.join((file_path, 'SHA256SUM'))
+        hash_file_path = '.'.join((file_path, hash_type))
         if os.path.exists(hash_file_path):
             os.remove(hash_file_path)
 
@@ -128,6 +128,7 @@ class MiaUtils(object):
             zip_hash_value,
             os.path.basename(file_path),
         )))
+        hf.write('')  # Add an extra empty line.
         hf.close()
 
     # TODO: Find a way to keep comments in the setting files.

--- a/mia/utils.py
+++ b/mia/utils.py
@@ -2,6 +2,7 @@
 Utilities for the mia script.
 """
 
+import hashlib
 import math
 import operator
 import os
@@ -96,6 +97,34 @@ class MiaUtils(object):
                     continue
 
             return value
+
+    @staticmethod
+    def get_file_hash(file_path):
+        # Read the file and compute the it's hash.
+        return hashlib.sha256(open(file_path, 'rb').read()).hexdigest()
+
+    @classmethod
+    def create_hash_file(cls, file_path):
+        # Get the human readable file size.
+        file_size = os.path.getsize(file_path)
+        file_size = cls.format_file_size(file_size)
+
+        # Get the file hash.
+        print(' - computing hash of {}'. format(file_size))
+        zip_hash_value = cls.get_file_hash(file_path)
+
+        hash_file_path = '.'.join((file_path, 'SHA256SUM'))
+        if os.path.exists(hash_file_path):
+            os.remove(hash_file_path)
+
+        # Save the hash to a file.
+        hf = open(hash_file_path, mode='w')
+        # The '*' specifies that the file should be read in binary mode.
+        hf.write(' *'.join((
+            zip_hash_value,
+            os.path.basename(file_path),
+        )))
+        hf.close()
 
     # TODO: Find a way to keep comments in the setting files.
     @staticmethod

--- a/mia/utils.py
+++ b/mia/utils.py
@@ -99,9 +99,13 @@ class MiaUtils(object):
             return value
 
     @staticmethod
-    def get_file_hash(file_path):
+    def get_file_hash(file_path, hash_type='sha256'):
         # Read the file and compute the it's hash.
-        return hashlib.sha256(open(file_path, 'rb').read()).hexdigest()
+        if hash_type not in hashlib.algorithms_available:
+            raise ValueError('Unknown hash type: {}'.format(hash_type))
+
+        with open(file_path, 'rb') as file_object:
+            return hashlib.new(hash_type, file_object.read()).hexdigest()
 
     @classmethod
     def create_hash_file(cls, file_path):


### PR DESCRIPTION
The built zip is now verified so that we have a valid zip file and we generate a checksum file, that isn't used at the moment.

Added hash and hash_type to the schema.yaml and also updated `get_definition_settings()` to actually provide the default values, and not handle them all over the code. (eg: "sha256" as default for apps hash_type)

And the provided hashes are checked against the hashes from the repository index.xml. And the downloaded AKS are verified against the hashes from the lock file.

Next:
* We need to check the update.zip checksum during the OpenRecoveryScript.
* Check APKs once again when adding them to the update.zip ?!? or not?